### PR TITLE
Add Streamlit config

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[server]
+fileWatcherType = "poll"


### PR DESCRIPTION
## Summary
- enable server file watching configuration with polling

## Testing
- `bash run.sh` *(fails: Could not find a version that satisfies the requirement streamlit)*