### PR TITLE
Update sentence-transformers dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pandas==2.0.3
 scikit-learn==1.3.0
 # Fix the huggingface_hub and sentence-transformers versions to be compatible
 huggingface_hub==0.12.1
-sentence-transformers==2.1.0
+sentence-transformers==2.2.2
 PyPDF2==3.0.1
 openpyxl==3.1.2
 Cython==0.29.37


### PR DESCRIPTION
## Summary
- update `sentence-transformers` to version 2.2.2

## Testing
- `python -m py_compile app.py advanced_nlp.py update_program_data.py`
- `python update_program_data.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
