### PR TITLE
Fix spaCy model setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ This is a Streamlit-based content recommendation engine that processes natural l
    ```
    pip install -r requirements.txt
    ```
-3. Download the required NLTK data (the application will attempt to do this automatically)
+3. Download the spaCy English model:
+   ```
+   python -m spacy download en_core_web_sm
+   ```
+4. Download the required NLTK data (the application will attempt to do this automatically)
 
 ## Usage
 

--- a/advanced_nlp.py
+++ b/advanced_nlp.py
@@ -19,17 +19,20 @@ except ImportError:
 DEFAULT_EMBEDDING_MODEL = "all-mpnet-base-v2"
 
 # Try importing spaCy, but handle the error if it fails
+nlp = None
 try:
     import spacy
-    SPACY_AVAILABLE = True
-    # Try to load the model, but don't fail if it's not available
     try:
         nlp = spacy.load("en_core_web_sm")
-    except:
+        SPACY_AVAILABLE = True
+    except Exception as e:
+        print(f"Warning: spaCy model could not be loaded: {e}")
         SPACY_AVAILABLE = False
+        nlp = None
 except ImportError:
     print("Warning: spaCy could not be imported. Some NLP features will be limited.")
     SPACY_AVAILABLE = False
+    nlp = None
 
 # Ensure NLTK resources are downloaded
 try:

--- a/run.sh
+++ b/run.sh
@@ -3,6 +3,7 @@
 # Install dependencies
 echo "Installing dependencies..."
 python3 -m pip install -r requirements.txt
+python3 -m spacy download en_core_web_sm
 
 # Run the Streamlit app
 echo "Starting Content Recommendation Engine..."


### PR DESCRIPTION
## Summary
- install spaCy model automatically in run script
- document spaCy model download step in README

## Testing
- `python -m py_compile advanced_nlp.py app.py`
